### PR TITLE
non-blocking mode fix

### DIFF
--- a/Win-Net/Net/Net/Net/Net.cpp
+++ b/Win-Net/Net/Net/Net/Net.cpp
@@ -29,7 +29,6 @@
 #include <Net/Import/Ws2_32.hpp>
 
 extern void __Net_Enable_Logging();
-extern void __Net_Shutdown_Logging();
 
 #ifdef NET_TEST_MEMORY_LEAKS
 static void NET_TEST_MEMORY_SHOW_DIAGNOSTIC()
@@ -67,10 +66,6 @@ NET_EXPORT_FUNCTION void Net::load(int flag)
 
 NET_EXPORT_FUNCTION void Net::unload()
 {
-#ifndef NET_DISABLE_LOGMANAGER
-	__Net_Shutdown_Logging();
-#endif
-
 	Net::Codes::NetUnloadErrorCodes();
 
 #ifndef NET_DISABLE_IMPORT_WS2_32

--- a/Win-Net/Net/Net/Net/Net.h
+++ b/Win-Net/Net/Net/Net/Net.h
@@ -668,33 +668,32 @@ namespace WebServerHandshake
 
 /* OPTION BIT FLAGS */
 #define NET_OPT_FREQUENZ (1 << 0)
-#define NET_OPT_MODE_BLOCKING (1 << 1)
-#define NET_OPT_USE_CIPHER (1 << 2)
-#define NET_OPT_CIPHER_RSA_SIZE (1 << 3)
-#define NET_OPT_CIPHER_AES_SIZE (1 << 4)
-#define NET_OPT_USE_COMPRESSION (1 << 5)
-#define NET_OPT_INTERVAL_LATENCY (1 << 6)
-#define NET_OPT_NAME (1 << 7)
-#define NET_OPT_PORT (1 << 8)
-#define NET_OPT_SSL (1 << 9)
-#define NET_OPT_SSL_METHOD (1 << 10)
-#define NET_OPT_SSL_CERT (1 << 11)
-#define NET_OPT_SSL_KEY (1 << 12)
-#define NET_OPT_SSL_CA (1 << 13)
-#define NET_OPT_WS_CUSTOM_HANDSHAKE (1 << 14)
-#define NET_OPT_WS_CUSTOM_ORIGIN (1 << 15)
-#define NET_OPT_WS_NO_HANDSHAKE (1 << 16)
-#define NET_OPT_DISABLE_LATENCY_REQUEST (1 << 17)
+#define NET_OPT_USE_CIPHER (1 << 1)
+#define NET_OPT_CIPHER_RSA_SIZE (1 << 2)
+#define NET_OPT_CIPHER_AES_SIZE (1 << 3)
+#define NET_OPT_USE_COMPRESSION (1 << 4)
+#define NET_OPT_INTERVAL_LATENCY (1 << 5)
+#define NET_OPT_NAME (1 << 6)
+#define NET_OPT_PORT (1 << 7)
+#define NET_OPT_SSL (1 << 8)
+#define NET_OPT_SSL_METHOD (1 << 9)
+#define NET_OPT_SSL_CERT (1 << 10)
+#define NET_OPT_SSL_KEY (1 << 11)
+#define NET_OPT_SSL_CA (1 << 12)
+#define NET_OPT_WS_CUSTOM_HANDSHAKE (1 << 13)
+#define NET_OPT_WS_CUSTOM_ORIGIN (1 << 14)
+#define NET_OPT_WS_NO_HANDSHAKE (1 << 15)
+#define NET_OPT_DISABLE_LATENCY_REQUEST (1 << 16)
 
 /* TIMER TO DISCONNECT PEERS FROM USING WRONG PROTOCOL */
-#define NET_OPT_NET_PROTOCOL_CHECK_TIME (1 << 18)
+#define NET_OPT_NET_PROTOCOL_CHECK_TIME (1 << 17)
 
-#define NET_OPT_NET_PROTOCOL_HEARTBEAT_INTERVAL (1 << 19)
-#define NET_OPT_NET_PROTOCOL_HEARTBEAT_TOLERANT_TIME (1 << 20)
+#define NET_OPT_NET_PROTOCOL_HEARTBEAT_INTERVAL (1 << 18)
+#define NET_OPT_NET_PROTOCOL_HEARTBEAT_TOLERANT_TIME (1 << 19)
 
-#define NET_OPT_MAX_PEERS_THREAD (1 << 21)
+#define NET_OPT_MAX_PEERS_THREAD (1 << 20)
 
-#define NET_OPT_USE_HEARTBEAT (1 << 22)
+#define NET_OPT_USE_HEARTBEAT (1 << 21)
 
 /* Server & Client Option */
 
@@ -703,7 +702,7 @@ namespace WebServerHandshake
 * without this option, any callback that might perform some big job will block the socket from further execution
 * enable this option to perform the job in a seperate thread
 */
-#define NET_OPT_EXECUTE_PACKET_ASYNC (1 << 23)
+#define NET_OPT_EXECUTE_PACKET_ASYNC (1 << 22)
 #define NET_OPT_DEFAULT_EXECUTE_PACKET_ASYNC false
 
 /* DEFAULT OPTION VALUES */
@@ -713,9 +712,7 @@ namespace WebServerHandshake
 #define NET_OPT_DEFAULT_USE_CIPHER false
 #define NET_OPT_DEFAULT_USE_COMPRESSION false
 #define NET_OPT_DEFAULT_FREQUENZ 66
-#define NET_OPT_DEFAULT_MODE_BLOCKING false
 #define NET_OPT_DEFAULT_INTERVAL_LATENCY 1000
-#define NET_OPT_DEFAULT_TIMEOUT_TCP_READ 10
 #define NET_OPT_DEFAULT_NAME CSTRING("UNKNOWN")
 #define NET_OPT_DEFAULT_PORT 1337
 #define NET_OPT_DEFAULT_LATENCY_REQUEST false

--- a/Win-Net/Net/Net/Net/Net.h
+++ b/Win-Net/Net/Net/Net/Net.h
@@ -673,28 +673,27 @@ namespace WebServerHandshake
 #define NET_OPT_CIPHER_AES_SIZE (1 << 4)
 #define NET_OPT_USE_COMPRESSION (1 << 5)
 #define NET_OPT_INTERVAL_LATENCY (1 << 6)
-#define NET_OPT_TIMEOUT_TCP_READ (1 << 7)
-#define NET_OPT_NAME (1 << 8)
-#define NET_OPT_PORT (1 << 9)
-#define NET_OPT_SSL (1 << 10)
-#define NET_OPT_SSL_METHOD (1 << 11)
-#define NET_OPT_SSL_CERT (1 << 12)
-#define NET_OPT_SSL_KEY (1 << 13)
-#define NET_OPT_SSL_CA (1 << 14)
-#define NET_OPT_WS_CUSTOM_HANDSHAKE (1 << 15)
-#define NET_OPT_WS_CUSTOM_ORIGIN (1 << 16)
-#define NET_OPT_WS_NO_HANDSHAKE (1 << 17)
-#define NET_OPT_DISABLE_LATENCY_REQUEST (1 << 18)
+#define NET_OPT_NAME (1 << 7)
+#define NET_OPT_PORT (1 << 8)
+#define NET_OPT_SSL (1 << 9)
+#define NET_OPT_SSL_METHOD (1 << 10)
+#define NET_OPT_SSL_CERT (1 << 11)
+#define NET_OPT_SSL_KEY (1 << 12)
+#define NET_OPT_SSL_CA (1 << 13)
+#define NET_OPT_WS_CUSTOM_HANDSHAKE (1 << 14)
+#define NET_OPT_WS_CUSTOM_ORIGIN (1 << 15)
+#define NET_OPT_WS_NO_HANDSHAKE (1 << 16)
+#define NET_OPT_DISABLE_LATENCY_REQUEST (1 << 17)
 
 /* TIMER TO DISCONNECT PEERS FROM USING WRONG PROTOCOL */
-#define NET_OPT_NET_PROTOCOL_CHECK_TIME (1 << 19)
+#define NET_OPT_NET_PROTOCOL_CHECK_TIME (1 << 18)
 
-#define NET_OPT_NET_PROTOCOL_HEARTBEAT_INTERVAL (1 << 20)
-#define NET_OPT_NET_PROTOCOL_HEARTBEAT_TOLERANT_TIME (1 << 21)
+#define NET_OPT_NET_PROTOCOL_HEARTBEAT_INTERVAL (1 << 19)
+#define NET_OPT_NET_PROTOCOL_HEARTBEAT_TOLERANT_TIME (1 << 20)
 
-#define NET_OPT_MAX_PEERS_THREAD (1 << 22)
+#define NET_OPT_MAX_PEERS_THREAD (1 << 21)
 
-#define NET_OPT_USE_HEARTBEAT (1 << 23)
+#define NET_OPT_USE_HEARTBEAT (1 << 22)
 
 /* Server & Client Option */
 
@@ -703,7 +702,7 @@ namespace WebServerHandshake
 * without this option, any callback that might perform some big job will block the socket from further execution
 * enable this option to perform the job in a seperate thread
 */
-#define NET_OPT_EXECUTE_PACKET_ASYNC (1 << 24)
+#define NET_OPT_EXECUTE_PACKET_ASYNC (1 << 23)
 #define NET_OPT_DEFAULT_EXECUTE_PACKET_ASYNC false
 
 /* DEFAULT OPTION VALUES */

--- a/Win-Net/Net/Net/Net/Net.h
+++ b/Win-Net/Net/Net/Net/Net.h
@@ -82,6 +82,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <cmath>
+#include <fcntl.h>
 #endif
 
 #ifndef BUILD_LINUX

--- a/Win-Net/Net/Net/Net/NetPeerPool.cpp
+++ b/Win-Net/Net/Net/Net/NetPeerPool.cpp
@@ -258,7 +258,7 @@ NET_THREAD(threadpool_manager)
 			return NULL;
 		}
 
-		if (take_rest)
+		/*if (take_rest)
 		{
 			auto fncSleepPointer = pClass->get_sleep_function();
 			if (fncSleepPointer)
@@ -270,7 +270,7 @@ NET_THREAD(threadpool_manager)
 			{
 				std::this_thread::sleep_for(std::chrono::milliseconds(pClass->get_sleep_time()));
 			}
-		}
+		}*/
 	}
 
 	FREE<threadpool_manager_data_t>(data);

--- a/Win-Net/Net/Net/Net/NetPeerPool.cpp
+++ b/Win-Net/Net/Net/Net/NetPeerPool.cpp
@@ -133,7 +133,6 @@ size_t Net::PeerPool::PeerPool_t::get_max_peers()
 
 bool Net::PeerPool::PeerPool_t::check_more_threads_needed()
 {
-	//const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
 	for (const auto& pool : peer_threadpool)
 	{
 		if (count_peers(pool) != max_peers)
@@ -147,7 +146,6 @@ bool Net::PeerPool::PeerPool_t::check_more_threads_needed()
 
 void Net::PeerPool::PeerPool_t::threapool_push(peer_threadpool_t* pool)
 {
-	//const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
 	peer_threadpool.emplace_back(pool);
 }
 
@@ -210,7 +208,7 @@ NET_THREAD(threadpool_manager)
 			case Net::PeerPool::WorkStatus_t::CONTINUE:
 			{
 				/* move peers into available threads to reduce the amount of running threads */
-				//const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
+				const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
 				const auto p = pClass->threadpool_get_free_slot_in_target_pool(pool);
 				if (p)
 				{
@@ -245,7 +243,7 @@ NET_THREAD(threadpool_manager)
 		if (pClass->count_peers(pool) == 0)
 		{
 			// erase from vector
-			//const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
+			const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
 			for (auto it = pClass->get_peer_threadpool().begin(); it != pClass->get_peer_threadpool().end(); it++)
 			{
 				auto p = *it;
@@ -342,7 +340,6 @@ Net::PeerPool::peerInfo_t* Net::PeerPool::PeerPool_t::queue_pop()
 		return nullptr;
 	}
 
-	//	const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
 	auto peer = peer_queue.back();
 	peer_queue.pop_back();
 	return peer;
@@ -360,7 +357,6 @@ std::recursive_mutex* Net::PeerPool::PeerPool_t::get_peer_threadpool_mutex()
 
 void Net::PeerPool::PeerPool_t::add(peerInfo_t info)
 {
-	//const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
 	peer_queue.emplace_back(ALLOC<peerInfo_t, peerInfo_t>(1, info));
 
 	if (check_more_threads_needed())
@@ -371,7 +367,6 @@ void Net::PeerPool::PeerPool_t::add(peerInfo_t info)
 
 void Net::PeerPool::PeerPool_t::add(peerInfo_t* info)
 {
-	//const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
 	peer_queue.emplace_back(info);
 
 	if (check_more_threads_needed())
@@ -384,7 +379,6 @@ size_t Net::PeerPool::PeerPool_t::count_peers_all()
 {
 	size_t peers = 0;
 
-	//const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
 	for (const auto pool : peer_threadpool)
 	{
 		for (size_t i = 0; i < get_max_peers(); ++i)

--- a/Win-Net/Net/Net/Net/NetPeerPool.cpp
+++ b/Win-Net/Net/Net/Net/NetPeerPool.cpp
@@ -133,7 +133,7 @@ size_t Net::PeerPool::PeerPool_t::get_max_peers()
 
 bool Net::PeerPool::PeerPool_t::check_more_threads_needed()
 {
-	const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
+	//const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
 	for (const auto& pool : peer_threadpool)
 	{
 		if (count_peers(pool) != max_peers)
@@ -145,7 +145,7 @@ bool Net::PeerPool::PeerPool_t::check_more_threads_needed()
 
 void Net::PeerPool::PeerPool_t::threapool_push(peer_threadpool_t* pool)
 {
-	const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
+	//const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
 	peer_threadpool.emplace_back(pool);
 }
 
@@ -206,7 +206,7 @@ NET_THREAD(threadpool_manager)
 			case Net::PeerPool::WorkStatus_t::CONTINUE:
 			{
 				/* move peers into available threads to reduce the amount of running threads */
-				const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
+				//const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
 				const auto p = pClass->threadpool_get_free_slot_in_target_pool(pool);
 				if (p)
 				{
@@ -241,7 +241,7 @@ NET_THREAD(threadpool_manager)
 		if (pClass->count_peers(pool) == 0)
 		{
 			// erase from vector
-			const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
+			//const std::lock_guard<std::recursive_mutex> lock(*pClass->get_peer_threadpool_mutex());
 			for (auto it = pClass->get_peer_threadpool().begin(); it != pClass->get_peer_threadpool().end(); it++)
 			{
 				auto p = *it;
@@ -323,7 +323,7 @@ Net::PeerPool::peerInfo_t* Net::PeerPool::PeerPool_t::queue_pop()
 {
 	if (peer_queue.empty()) return nullptr;
 
-	const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
+//	const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
 	auto peer = peer_queue.back();
 	peer_queue.pop_back();
 	return peer;
@@ -341,7 +341,7 @@ std::recursive_mutex* Net::PeerPool::PeerPool_t::get_peer_threadpool_mutex()
 
 void Net::PeerPool::PeerPool_t::add(peerInfo_t info)
 {
-	const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
+	//const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
 	peer_queue.emplace_back(new peerInfo_t(info));
 
 	if (check_more_threads_needed())
@@ -350,7 +350,7 @@ void Net::PeerPool::PeerPool_t::add(peerInfo_t info)
 
 void Net::PeerPool::PeerPool_t::add(peerInfo_t* info)
 {
-	const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
+	//const std::lock_guard<std::recursive_mutex> lock(peer_mutex);
 	peer_queue.emplace_back(info);
 
 	if (check_more_threads_needed())
@@ -361,7 +361,7 @@ size_t Net::PeerPool::PeerPool_t::count_peers_all()
 {
 	size_t peers = 0;
 
-	const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
+	//const std::lock_guard<std::recursive_mutex> lock(peer_threadpool_mutex);
 	for (const auto pool : peer_threadpool)
 		for (size_t i = 0; i < get_max_peers(); ++i)
 		{

--- a/Win-Net/Net/Net/Net/NetPeerPool.h
+++ b/Win-Net/Net/Net/Net/NetPeerPool.h
@@ -78,9 +78,6 @@ namespace Net
 			void threapool_push(peer_threadpool_t* pool);
 			void threadpool_add();
 
-			DWORD ms_sleep_time;
-			void (*fncSleep)(DWORD time);
-
 			size_t max_peers;
 
 		public:
@@ -92,12 +89,6 @@ namespace Net
 			std::recursive_mutex* get_peer_threadpool_mutex();
 
 			peer_threadpool_t* threadpool_get_free_slot_in_target_pool(peer_threadpool_t* from_pool);
-
-			void set_sleep_time(DWORD ms_sleep_time);
-			DWORD get_sleep_time();
-
-			void set_sleep_function(void (*fncSleep)(DWORD time));
-			void* get_sleep_function();
 
 			void set_max_peers(size_t max_peers);
 			size_t get_max_peers();

--- a/Win-Net/Net/Net/Net/NetPeerPool.h
+++ b/Win-Net/Net/Net/Net/NetPeerPool.h
@@ -78,6 +78,9 @@ namespace Net
 			void threapool_push(peer_threadpool_t* pool);
 			void threadpool_add();
 
+			DWORD ms_sleep_time;
+			void (*fncSleep)(DWORD time);
+
 			size_t max_peers;
 
 		public:
@@ -89,6 +92,12 @@ namespace Net
 			std::recursive_mutex* get_peer_threadpool_mutex();
 
 			peer_threadpool_t* threadpool_get_free_slot_in_target_pool(peer_threadpool_t* from_pool);
+
+			void set_sleep_time(DWORD ms_sleep_time);
+			DWORD get_sleep_time();
+
+			void set_sleep_function(void (*fncSleep)(DWORD time));
+			void* get_sleep_function();
 
 			void set_max_peers(size_t max_peers);
 			size_t get_max_peers();

--- a/Win-Net/Net/Net/assets/manager/logmanager.h
+++ b/Win-Net/Net/Net/assets/manager/logmanager.h
@@ -130,16 +130,16 @@ Net::Console::NET_LOG(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
 #define NET_LOG_SUCCESS(...)
 #else
 #define NET_LOG(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::normal, FUNCNAME, __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::normal, FUNCNAME, __VA_ARGS__);
 
 #define NET_LOG_ERROR(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::error, FUNCNAME, __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::error, FUNCNAME, __VA_ARGS__);
 
 #define NET_LOG_WARNING(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::warning, FUNCNAME, __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::warning, FUNCNAME, __VA_ARGS__);
 
 #define NET_LOG_SUCCESS(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::success, FUNCNAME, __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::success, FUNCNAME, __VA_ARGS__);
 #endif
 
 #ifdef DEBUG
@@ -147,7 +147,7 @@ Net::Console::NET_LOG(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
 #define NET_LOG_DEBUG(...)
 #else
 #define NET_LOG_DEBUG(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::debug, FUNCNAME, __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::debug, FUNCNAME, __VA_ARGS__);
 #endif
 #else
 #define NET_LOG_DEBUG(...)
@@ -157,7 +157,7 @@ Net::Console::NET_LOG(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
 #define NET_LOG_PEER(...)
 #else
 #define NET_LOG_PEER(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::peer, FUNCNAME, __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::peer, FUNCNAME, __VA_ARGS__);
 #endif
 
 ////////////// LOG NO FUNCTION NAME
@@ -168,16 +168,16 @@ Net::Console::NET_LOG(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
 #define NET_NNET_LOG_SUCCESS(...)
 #else
 #define NET_NNET_LOG(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::normal, CSTRING(""), __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::normal, CSTRING(""), __VA_ARGS__);
 
 #define NET_NNET_LOG_ERROR(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::error, CSTRING(""), __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::error, CSTRING(""), __VA_ARGS__);
 
 #define NET_NNET_LOG_WARNING(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::warning, CSTRING(""), __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::warning, CSTRING(""), __VA_ARGS__);
 
 #define NET_NNET_LOG_SUCCESS(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::success, CSTRING(""), __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::success, CSTRING(""), __VA_ARGS__);
 #endif
 
 #ifdef DEBUG
@@ -185,7 +185,7 @@ Net::Console::NET_LOG(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
 #define NET_NNET_LOG_DEBUG(...)
 #else
 #define NET_NNET_LOG_DEBUG(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::debug, CSTRING(""), __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::debug, CSTRING(""), __VA_ARGS__);
 #endif
 #else
 #define NNET_LOG_DEBUG(...)
@@ -195,21 +195,9 @@ Net::Console::NET_LOG(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
 #define NET_NNET_LOG_PEER(...)
 #else
 #define NET_NNET_LOG_PEER(...) \
-	Net::Manager::Log::Log(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
+	Net::Console::Log(Net::Console::LogStates::peer, CSTRING(""), __VA_ARGS__);
 #endif
 ///////////////////////
-
-/* LOG (FILENAME) */
-#ifdef NET_DISABLE_LOGMANAGER
-#define NET_BEGIN_NET_LOG(fname)
-#define NET_END_LOG
-#else
-#define NET_BEGIN_NET_LOG(fname) \
-	Net::Manager::Log::SetOutputName(fname);
-
-#define NET_END_LOG \
-	Net::Manager::Log::SetOutputName(CSTRING(""));
-#endif
 
 namespace Net
 {
@@ -228,6 +216,9 @@ namespace Net
 #endif
 		NET_EXPORT_FUNCTION tm TM_GetTime();
 #ifndef NET_DISABLE_LOGMANAGER
+		NET_EXPORT_FUNCTION void SetLogCallbackA(OnLogA_t);
+		NET_EXPORT_FUNCTION void SetLogCallbackW(OnLogW_t);
+
 		NET_EXPORT_FUNCTION std::string GetLogStatePrefix(LogStates);
 		NET_EXPORT_FUNCTION void Log(LogStates, const char*, const char*, ...);
 		NET_EXPORT_FUNCTION void Log(LogStates, const char*, const wchar_t*, ...);
@@ -240,26 +231,6 @@ namespace Net
 		NET_EXPORT_FUNCTION bool GetPrintFState();
 		NET_EXPORT_FUNCTION WORD GetColorFromState(LogStates);
 #endif
-	}
-
-	namespace Manager
-	{
-		namespace Log
-		{
-#ifndef NET_DISABLE_LOGMANAGER
-			void start();
-			void shutdown();
-			NET_EXPORT_FUNCTION void SetOutputName(const char*);
-			NET_EXPORT_FUNCTION void SetLogCallbackA(OnLogA_t);
-			NET_EXPORT_FUNCTION void SetLogCallbackW(OnLogW_t);
-			NET_EXPORT_FUNCTION void Log(Console::LogStates, const char*, const char*, ...);
-			NET_EXPORT_FUNCTION void Log(Console::LogStates, const char*, const wchar_t*, ...);
-			NET_EXPORT_FUNCTION void Log(Console::LogStates, const char*, Net::String);
-			NET_EXPORT_FUNCTION void Log(Console::LogStates, const char*, Net::String&);
-			NET_EXPORT_FUNCTION void Log(Console::LogStates, const char*, Net::ViewString);
-			NET_EXPORT_FUNCTION void Log(Console::LogStates, const char*, Net::ViewString&);
-#endif
-		}
 	}
 }
 NET_DSA_END

--- a/Win-Net/Net/Net/assets/manager/profile.hpp
+++ b/Win-Net/Net/Net/assets/manager/profile.hpp
@@ -155,13 +155,15 @@ namespace Net
 			{
 				if (data == nullptr)
 				{
-					return;
+					return nullptr;
 				}
 
 				for (size_t i = 0; i < max_entries; ++i)
 				{
 					if (data[i].Peer<void*>() == peer)
+					{
 						return data[i].ext;
+					}
 				}
 
 				return nullptr;
@@ -188,13 +190,15 @@ namespace Net
 			{
 				if (data == nullptr)
 				{
-					return;
+					return nullptr;
 				}
 
 				for (size_t i = 0; i < max_entries; ++i)
 				{
 					if (data[i].Peer<void*>() == peer)
+					{
 						return &data[i].data;
+					}
 				}
 
 				return nullptr;

--- a/Win-Net/Net/Net/assets/manager/profile.hpp
+++ b/Win-Net/Net/Net/assets/manager/profile.hpp
@@ -78,16 +78,21 @@ namespace Net
 			NET_PROFILE_DATA* data;
 			size_t max_entries;
 			size_t c_entries;
-			std::recursive_mutex critical;
 
 			size_t get_free_slot()
 			{
-				if (!data) return INVALID_SIZE;
-
-				std::lock_guard<std::recursive_mutex> guard(critical);
+				if (data == nullptr)
+				{
+					return INVALID_SIZE;
+				}
 
 				for (size_t i = 0; i < max_entries; ++i)
-					if (data[i].Peer<void*>() == nullptr) return i;
+				{
+					if (data[i].Peer<void*>() == nullptr) 
+					{
+						return i;
+					}
+				}
 
 				// indicates all slots are being in use
 				return INVALID_SIZE;
@@ -116,7 +121,10 @@ namespace Net
 
 			Net::Json::Document* Add(void* peer)
 			{
-				if (!data) return nullptr;
+				if (data == nullptr) 
+				{
+					return nullptr;
+				}
 
 				auto slot = get_free_slot();
 				if (slot == INVALID_SIZE) return nullptr;
@@ -127,7 +135,10 @@ namespace Net
 
 			void Remove(void* peer)
 			{
-				if (!data) return;
+				if (data == nullptr)
+				{
+					return;
+				}
 
 				for (size_t i = 0; i < max_entries; ++i)
 				{
@@ -142,7 +153,10 @@ namespace Net
 
 			void* peerExt(void* peer)
 			{
-				if (!data) return nullptr;
+				if (data == nullptr)
+				{
+					return;
+				}
 
 				for (size_t i = 0; i < max_entries; ++i)
 				{
@@ -155,7 +169,10 @@ namespace Net
 
 			void setPeerExt(void* peer, void* ext)
 			{
-				if (!data) return;
+				if (data == nullptr)
+				{
+					return;
+				}
 
 				for (size_t i = 0; i < max_entries; ++i)
 				{
@@ -169,7 +186,10 @@ namespace Net
 
 			Net::Json::Document* peer(void* peer)
 			{
-				if (!data) return nullptr;
+				if (data == nullptr)
+				{
+					return;
+				}
 
 				for (size_t i = 0; i < max_entries; ++i)
 				{

--- a/Win-Net/Net/NetClient/Client.cpp
+++ b/Win-Net/Net/NetClient/Client.cpp
@@ -352,11 +352,7 @@ namespace Net
 #endif
 								{
 									bBlocked = true;
-#ifdef BUILD_LINUX
-									usleep(FREQUENZ * 1000);
-#else
-									Kernel32::Sleep(FREQUENZ);
-#endif
+									continue;
 								}
 							}
 
@@ -394,11 +390,7 @@ namespace Net
 #endif
 							{
 								bBlocked = true;
-#ifdef BUILD_LINUX
-								usleep(FREQUENZ * 1000);
-#else
-								Kernel32::Sleep(FREQUENZ);
-#endif
+								continue;
 							}
 						}
 
@@ -508,14 +500,9 @@ namespace Net
 #else
 						if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 #endif
-
 						{
 							bBlocked = true;
-#ifdef BUILD_LINUX
-							usleep(FREQUENZ * 1000);
-#else
-							Kernel32::Sleep(FREQUENZ);
-#endif
+							continue;
 						}
 					}
 
@@ -687,7 +674,6 @@ namespace Net
 #ifdef BUILD_LINUX
 					if (errno == EWOULDBLOCK)
 					{
-						usleep(FREQUENZ * 1000);
 						continue;
 					}
 					else
@@ -700,7 +686,6 @@ namespace Net
 #else
 					if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 					{
-						Kernel32::Sleep(FREQUENZ);
 						continue;
 					}
 					else
@@ -741,7 +726,6 @@ namespace Net
 #ifdef BUILD_LINUX
 					if (errno == EWOULDBLOCK)
 					{
-						usleep(FREQUENZ * 1000);
 						continue;
 					}
 					else
@@ -755,7 +739,6 @@ namespace Net
 #else
 					if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 					{
-						Kernel32::Sleep(FREQUENZ);
 						continue;
 					}
 					else
@@ -799,7 +782,6 @@ namespace Net
 #ifdef BUILD_LINUX
 					if (errno == EWOULDBLOCK)
 					{
-						usleep(FREQUENZ * 1000);
 						continue;
 					}
 					else
@@ -813,7 +795,6 @@ namespace Net
 #else
 					if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 					{
-						Kernel32::Sleep(FREQUENZ);
 						continue;
 					}
 					else
@@ -860,7 +841,6 @@ namespace Net
 #ifdef BUILD_LINUX
 					if (errno == EWOULDBLOCK)
 					{
-						usleep(FREQUENZ * 1000);
 						continue;
 					}
 					else
@@ -874,7 +854,6 @@ namespace Net
 #else
 					if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 					{
-						Kernel32::Sleep(FREQUENZ);
 						continue;
 					}
 					else

--- a/Win-Net/Net/NetClient/Client.cpp
+++ b/Win-Net/Net/NetClient/Client.cpp
@@ -423,12 +423,6 @@ namespace Net
 			// Set Mode
 			ChangeMode(Isset(NET_OPT_MODE_BLOCKING) ? GetOption<bool>(NET_OPT_MODE_BLOCKING) : NET_OPT_DEFAULT_MODE_BLOCKING);
 
-			/* Set Read Timeout */
-			timeval tv = {};
-			tv.tv_sec = Isset(NET_OPT_TIMEOUT_TCP_READ) ? GetOption<long>(NET_OPT_TIMEOUT_TCP_READ) : NET_OPT_DEFAULT_TIMEOUT_TCP_READ;
-			tv.tv_usec = 0;
-			Ws2_32::setsockopt(GetSocket(), SOL_SOCKET, SO_RCVTIMEO, (char*)&tv, sizeof tv);
-
 			// Set socket options
 			for (const auto& entry : socketoption)
 			{

--- a/Win-Net/Net/NetClient/Client.cpp
+++ b/Win-Net/Net/NetClient/Client.cpp
@@ -1259,7 +1259,7 @@ namespace Net
 				ProcessPackets();
 				memset(network.dataReceive, 0, NET_OPT_DEFAULT_MAX_PACKET_SIZE);
 				return FREQUENZ(this);
-			}
+		}
 
 			// graceful disconnect
 			if (data_size == 0)
@@ -1301,7 +1301,7 @@ namespace Net
 			memset(network.dataReceive, 0, NET_OPT_DEFAULT_MAX_PACKET_SIZE);
 			ProcessPackets();
 			return 0;
-		}
+	}
 
 		void Client::ProcessPackets()
 		{
@@ -2021,7 +2021,7 @@ namespace Net
 
 			/* base64 encode it */
 			NET_BASE64::encode(data, size);
-		}
+}
 
 		void Client::CompressData(BYTE*& data, BYTE*& out, size_t& size, const bool skip_free)
 		{

--- a/Win-Net/Net/NetClient/Client.h
+++ b/Win-Net/Net/NetClient/Client.h
@@ -245,8 +245,6 @@ namespace Net
 			Client();
 			~Client();
 
-			bool ChangeMode(bool);
-
 			char* ResolveHostname(const char*);
 			bool Connect(const char*, u_short);
 			bool Disconnect();

--- a/Win-Net/Net/NetClient/Client.h
+++ b/Win-Net/Net/NetClient/Client.h
@@ -61,7 +61,7 @@ return true; \
 
 #define NET_SEND DoSend
 
-#define FREQUENZ Isset(NET_OPT_FREQUENZ) ? GetOption<DWORD>(NET_OPT_FREQUENZ) : NET_OPT_DEFAULT_FREQUENZ
+#define FREQUENZ(x) x->Isset(NET_OPT_FREQUENZ) ? x->GetOption<DWORD>(NET_OPT_FREQUENZ) : NET_OPT_DEFAULT_FREQUENZ
 
 #include <Net/Net/Net.h>
 #include <Net/Net/NetPacket.h>
@@ -268,7 +268,6 @@ namespace Net
 			size_t GetReceivedPacketSize() const;
 			float GetReceivedPacketSizeAsPerc() const;
 
-			bool bReceiveThread;
 			DWORD DoReceive();
 
 		public:

--- a/Win-Net/Net/NetServer/Server.cpp
+++ b/Win-Net/Net/NetServer/Server.cpp
@@ -220,12 +220,6 @@ Net::Server::Server::peerInfo* Net::Server::Server::CreatePeer(const sockaddr_in
 	peer->pSocket = socket;
 	peer->client_addr = client_addr;
 
-	/* Set Read Timeout */
-	timeval tv = {};
-	tv.tv_sec = Isset(NET_OPT_TIMEOUT_TCP_READ) ? GetOption<long>(NET_OPT_TIMEOUT_TCP_READ) : NET_OPT_DEFAULT_TIMEOUT_TCP_READ;
-	tv.tv_usec = 0;
-	Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&tv, sizeof tv);
-
 	// Set socket options
 	for (const auto& entry : socketoption)
 	{

--- a/Win-Net/Net/NetServer/Server.cpp
+++ b/Win-Net/Net/NetServer/Server.cpp
@@ -886,7 +886,9 @@ void Net::Server::Server::DoSend(NET_PEER peer, const int id, NET_PACKET& pkg)
 	);
 
 	if (peer->bErase)
+	{
 		return;
+	}
 
 	std::lock_guard<std::mutex> guard(peer->network._mutex_send);
 

--- a/Win-Net/Net/NetServer/Server.cpp
+++ b/Win-Net/Net/NetServer/Server.cpp
@@ -274,11 +274,7 @@ bool Net::Server::Server::ErasePeer(NET_PEER peer, bool clear)
 #endif
 					{
 						bBlocked = true;
-#ifdef BUILD_LINUX
-						usleep(FREQUENZ(this) * 1000);
-#else
-						Kernel32::Sleep(FREQUENZ(this));
-#endif
+						continue;
 					}
 				}
 
@@ -650,7 +646,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, const char* data, size_t siz
 #ifdef BUILD_LINUX
 			if (errno == EWOULDBLOCK)
 			{
-				usleep(FREQUENZ(this) * 1000);
 				continue;
 			}
 			else
@@ -663,7 +658,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, const char* data, size_t siz
 #else
 			if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 			{
-				Kernel32::Sleep(FREQUENZ(this));
 				continue;
 			}
 			else
@@ -709,7 +703,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, BYTE*& data, size_t size, bo
 #ifdef BUILD_LINUX
 			if (errno == EWOULDBLOCK)
 			{
-				usleep(FREQUENZ(this) * 1000);
 				continue;
 			}
 			else
@@ -723,7 +716,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, BYTE*& data, size_t size, bo
 #else
 			if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 			{
-				Kernel32::Sleep(FREQUENZ(this));
 				continue;
 			}
 			else
@@ -772,7 +764,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, NET_CPOINTER<BYTE>& data, si
 #ifdef BUILD_LINUX
 			if (errno == EWOULDBLOCK)
 			{
-				usleep(FREQUENZ(this) * 1000);
 				continue;
 			}
 			else
@@ -786,7 +777,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, NET_CPOINTER<BYTE>& data, si
 #else
 			if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 			{
-				Kernel32::Sleep(FREQUENZ(this));
 				continue;
 			}
 			else
@@ -838,7 +828,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, Net::RawData_t& data, bool& 
 #ifdef BUILD_LINUX
 			if (errno == EWOULDBLOCK)
 			{
-				usleep(FREQUENZ(this) * 1000);
 				continue;
 			}
 			else
@@ -852,7 +841,6 @@ void Net::Server::Server::SingleSend(NET_PEER peer, Net::RawData_t& data, bool& 
 #else
 			if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 			{
-				Kernel32::Sleep(FREQUENZ(this));
 				continue;
 			}
 			else
@@ -1341,11 +1329,7 @@ void Net::Server::Server::Acceptor()
 			if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 #endif
 			{
-#ifdef BUILD_LINUX
-				usleep(FREQUENZ(this) * 1000);
-#else
-				Kernel32::Sleep(FREQUENZ(this));
-#endif
+				continue;
 			}
 			else
 			{

--- a/Win-Net/Net/NetServer/Server.cpp
+++ b/Win-Net/Net/NetServer/Server.cpp
@@ -26,6 +26,28 @@
 #include <Net/Import/Kernel32.hpp>
 #include <Net/Import/Ws2_32.hpp>
 
+inline BYTE SetSocket2NonBlockingMode(SOCKET fd)
+{
+	if (fd < 0)
+	{
+		return 0;
+	}
+
+#ifdef BUILD_LINUX
+	int flags = fcntl(fd, F_GETFL, 0);
+	if (flags == -1)
+	{
+		return 0;
+	}
+
+	flags = (flags | O_NONBLOCK);
+	return (fcntl(fd, F_SETFL, flags) == 0) ? 1 : 0;
+#else
+	unsigned long mode = 1;
+	return (Ws2_32::ioctlsocket(fd, FIONBIO, &mode) == 0) ? 1 : 0;
+#endif
+}
+
 Net::Server::IPRef::IPRef(const char* pointer)
 {
 	this->pointer = (char*)pointer;
@@ -220,13 +242,41 @@ Net::Server::Server::peerInfo* Net::Server::Server::CreatePeer(const sockaddr_in
 	peer->pSocket = socket;
 	peer->client_addr = client_addr;
 
-	// Set socket options
+	/*
+	* This library is based on non-blocking sockets
+	* so we need to set the socket to non-blocking mode
+	*/
+	if (SetSocket2NonBlockingMode(socket) == 0)
+	{
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => failed to enable non-blocking for socket '%d'\n\tdiscarding socket"), SERVERNAME(this), socket);
+		return nullptr;
+	}
+
+	/*
+	* Set up socket for non-blocking mode
+	* Set everything to 0 so recv and send will return immediately
+	*/
+	{
+		timeval tv = {};
+		tv.tv_sec = 0;
+		tv.tv_usec = 0;
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_SNDBUF, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVBUF, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_SNDLOWAT, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVLOWAT, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_SNDTIMEO, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&tv, sizeof tv);
+	}
+
+	/*
+	* Set/override socket options
+	*/
 	for (const auto& entry : socketoption)
 	{
 		const auto res = Ws2_32::setsockopt(peer->pSocket, entry->level, entry->opt, entry->value(), entry->optlen());
 		if (res == SOCKET_ERROR)
 		{
-			NET_LOG_ERROR(CSTRING("'%s' => unable to apply socket option { %i : %i }"), SERVERNAME(this), entry->opt, LAST_ERROR);
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => failed to apply socket option { %i : %i } for socket '%d'"), SERVERNAME(this), entry->opt, LAST_ERROR, socket);
 		}
 	}
 
@@ -238,7 +288,7 @@ Net::Server::Server::peerInfo* Net::Server::Server::CreatePeer(const sockaddr_in
 		//peer->hCalcLatency = Timer::Create(CalcLatency, Isset(NET_OPT_INTERVAL_LATENCY) ? GetOption<int>(NET_OPT_INTERVAL_LATENCY) : NET_OPT_DEFAULT_INTERVAL_LATENCY, _CalcLatency, true);
 	}
 
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => New peer connected."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => New peer connected."), SERVERNAME(this), peer->IPAddr().get());
 
 	// callback
 	OnPeerConnect(peer);
@@ -302,7 +352,7 @@ bool Net::Server::Server::ErasePeer(NET_PEER peer, bool clear)
 		OnPeerDisconnect(peer, Ws2_32::WSAGetLastError());
 #endif
 
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => finished"), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => finished"), SERVERNAME(this), peer->IPAddr().get());
 
 		peer->clear();
 
@@ -403,11 +453,11 @@ void Net::Server::Server::DisconnectPeer(NET_PEER peer, const int code, const bo
 
 	if (code == 0)
 	{
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => disconnected"), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => disconnected"), SERVERNAME(this), peer->IPAddr().get());
 	}
 	else
 	{
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => disconnected due to the following reason '%s'"), SERVERNAME(this), peer->IPAddr().get(), Net::Codes::NetGetErrorMessage(code));
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => disconnected due to the following reason '%s'"), SERVERNAME(this), peer->IPAddr().get(), Net::Codes::NetGetErrorMessage(code));
 	}
 
 	ErasePeer(peer);
@@ -487,13 +537,13 @@ bool Net::Server::Server::Run()
 	res = Ws2_32::WSAStartup(MAKEWORD(2, 2), &wsaData);
 	if (res != NULL)
 	{
-		NET_LOG_ERROR(CSTRING("'%s' => [WSAStartup] failed with error: %d"), SERVERNAME(this), res);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => [WSAStartup] failed with error: %d"), SERVERNAME(this), res);
 		return false;
 	}
 
 	if (LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2)
 	{
-		NET_LOG_ERROR(CSTRING("'%s' => unable to find usable version of [Winsock.dll]"), SERVERNAME(this));
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => unable to find usable version of [Winsock.dll]"), SERVERNAME(this));
 		Ws2_32::WSACleanup();
 		return false;
 	}
@@ -510,7 +560,7 @@ bool Net::Server::Server::Run()
 	res = Ws2_32::getaddrinfo(NULLPTR, Port.data(), &hints, &result);
 
 	if (res != 0) {
-		NET_LOG_ERROR(CSTRING("'%s' => [getaddrinfo] failed with error: %d"), SERVERNAME(this), res);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => [getaddrinfo] failed with error: %d"), SERVERNAME(this), res);
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
 #endif
@@ -522,7 +572,7 @@ bool Net::Server::Server::Run()
 
 	if (GetListenSocket() == INVALID_SOCKET)
 	{
-		NET_LOG_ERROR(CSTRING("'%s' => creation of a listener socket failed with error: %ld"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => creation of a listener socket failed with error: %ld"), SERVERNAME(this), LAST_ERROR);
 		Ws2_32::freeaddrinfo(result);
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
@@ -530,13 +580,13 @@ bool Net::Server::Server::Run()
 		return false;
 	}
 
-	// Set the mode of the socket to be nonblocking
-	unsigned long iMode = 1;
-	res = Ws2_32::ioctlsocket(GetListenSocket(), FIONBIO, &iMode);
-
-	if (res == SOCKET_ERROR)
+	/*
+	* This library is based on non-blocking sockets
+	* so we need to set the socket to non-blocking mode
+	*/
+	if (SetSocket2NonBlockingMode(GetListenSocket()) == 0)
 	{
-		NET_LOG_ERROR(CSTRING("'%s' => [ioctlsocket] failed with error: %d"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => failed to enable non-blocking for socket '%d'\n\tdiscarding socket"), SERVERNAME(this), GetListenSocket());
 		Ws2_32::closesocket(GetListenSocket());
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
@@ -548,7 +598,7 @@ bool Net::Server::Server::Run()
 	res = Ws2_32::bind(GetListenSocket(), result->ai_addr, static_cast<int>(result->ai_addrlen));
 
 	if (res == SOCKET_ERROR) {
-		NET_LOG_ERROR(CSTRING("'%s' => [bind] failed with error: %d"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => [bind] failed with error: %d"), SERVERNAME(this), LAST_ERROR);
 		Ws2_32::freeaddrinfo(result);
 		Ws2_32::closesocket(GetListenSocket());
 #ifndef BUILD_LINUX
@@ -565,7 +615,7 @@ bool Net::Server::Server::Run()
 
 	if (res == SOCKET_ERROR)
 	{
-		NET_LOG_ERROR(CSTRING("'%s' => listen failed with error: %d"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => listen failed with error: %d"), SERVERNAME(this), LAST_ERROR);
 		Ws2_32::closesocket(GetListenSocket());
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
@@ -587,7 +637,7 @@ bool Net::Server::Server::Run()
 	Thread::Create(WorkThread, this);
 
 	SetRunning(true);
-	NET_LOG_SUCCESS(CSTRING("'%s' => running on port %d"), SERVERNAME(this), SERVERPORT(this));
+	NET_LOG_SUCCESS(CSTRING("WinNet :: Server('%s') => running on port %d"), SERVERNAME(this), SERVERPORT(this));
 	return true;
 }
 
@@ -595,7 +645,7 @@ bool Net::Server::Server::Close()
 {
 	if (!IsRunning())
 	{
-		NET_LOG_ERROR(CSTRING("'%s' => server is still running unable to close it"), SERVERNAME(this));
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => server is still running unable to close it"), SERVERNAME(this));
 		return false;
 	}
 
@@ -608,13 +658,15 @@ bool Net::Server::Server::Close()
 	SetRunning(false);
 
 	if (GetListenSocket())
+	{
 		Ws2_32::closesocket(GetListenSocket());
+	}
 
 #ifndef BUILD_LINUX
 	Ws2_32::WSACleanup();
 #endif
 
-	NET_LOG_DEBUG(CSTRING("'%s' => finished"), SERVERNAME(this));
+	NET_LOG_DEBUG(CSTRING("WinNet :: Server('%s') => finished"), SERVERNAME(this));
 	return true;
 }
 
@@ -624,9 +676,15 @@ void Net::Server::Server::SingleSend(NET_PEER peer, const char* data, size_t siz
 		return;
 	);
 
-	if (peer->bErase) return;
-	if (bPreviousSentFailed)
+	if (peer->bErase)
+	{
 		return;
+	}
+
+	if (bPreviousSentFailed)
+	{
+		return;
+	}
 
 	do
 	{
@@ -642,7 +700,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, const char* data, size_t siz
 			{
 				bPreviousSentFailed = true;
 				ErasePeer(peer);
-				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 				return;
 			}
 #else
@@ -654,7 +712,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, const char* data, size_t siz
 			{
 				bPreviousSentFailed = true;
 				ErasePeer(peer);
-				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 				return;
 			}
 #endif
@@ -700,7 +758,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, BYTE*& data, size_t size, bo
 				bPreviousSentFailed = true;
 				FREE<byte>(data);
 				ErasePeer(peer);
-				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 				return;
 			}
 #else
@@ -713,7 +771,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, BYTE*& data, size_t size, bo
 				bPreviousSentFailed = true;
 				FREE<byte>(data);
 				ErasePeer(peer);
-				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 				return;
 			}
 #endif
@@ -761,7 +819,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, NET_CPOINTER<BYTE>& data, si
 				bPreviousSentFailed = true;
 				data.free();
 				ErasePeer(peer);
-				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 				return;
 			}
 #else
@@ -774,7 +832,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, NET_CPOINTER<BYTE>& data, si
 				bPreviousSentFailed = true;
 				data.free();
 				ErasePeer(peer);
-				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 				return;
 			}
 #endif
@@ -825,7 +883,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, Net::RawData_t& data, bool& 
 				bPreviousSentFailed = true;
 				data.free();
 				ErasePeer(peer);
-				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+				if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 				return;
 			}
 #else
@@ -838,7 +896,7 @@ void Net::Server::Server::SingleSend(NET_PEER peer, Net::RawData_t& data, bool& 
 				bPreviousSentFailed = true;
 				data.free();
 				ErasePeer(peer);
-				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 				return;
 			}
 #endif
@@ -1245,7 +1303,7 @@ NET_TIMER(TimerPeerCheckAwaitNetProtocol)
 
 	if (peer->hWaitForNetProtocol == nullptr) NET_STOP_TIMER;
 
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => Peer did not response in time as expected from WinNet Protocol. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Peer did not response in time as expected from WinNet Protocol. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
 
 	server->ErasePeer(peer);
 
@@ -1269,7 +1327,7 @@ NET_TIMER(TimerPeerReceiveHeartbeat)
 		NET_STOP_TIMER;
 	}
 
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => Peer did not reply with heartbeat packet. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Peer did not reply with heartbeat packet. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
 
 	server->ErasePeer(peer);
 
@@ -1318,7 +1376,7 @@ void Net::Server::Server::Acceptor()
 		if (Ws2_32::WSAGetLastError() != WSAEWOULDBLOCK)
 #endif
 		{
-			NET_LOG_ERROR(CSTRING("'%s' => [accept] failed with error %d"), SERVERNAME(this), LAST_ERROR);
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => [accept] failed with error %d"), SERVERNAME(this), LAST_ERROR);
 		}
 
 		return;
@@ -1408,9 +1466,9 @@ bool Net::Server::Server::DoReceive(NET_PEER peer)
 			ErasePeer(peer);
 
 #ifdef BUILD_LINUX
-			if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+			if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 #else
-			if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+			if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 #endif
 
 			return true;
@@ -1426,7 +1484,7 @@ bool Net::Server::Server::DoReceive(NET_PEER peer)
 	{
 		peer->network.reset();
 		ErasePeer(peer);
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
 		return true;
 	}
 
@@ -2172,7 +2230,7 @@ void Net::Server::Server::CompressData(BYTE*& data, size_t& size)
 	size = m_iCompressedLen;
 
 #ifdef DEBUG
-	NET_LOG_DEBUG(CSTRING("'%s' => compressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
+	NET_LOG_DEBUG(CSTRING("WinNet :: Server('%s') => compressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
 #endif
 
 	/* base64 encode it */
@@ -2198,7 +2256,7 @@ void Net::Server::Server::CompressData(BYTE*& data, BYTE*& out, size_t& size, co
 	size = m_iCompressedLen;
 
 #ifdef DEBUG
-	NET_LOG_DEBUG(CSTRING("'%s' => compressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
+	NET_LOG_DEBUG(CSTRING("WinNet :: Server('%s') => compressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
 #endif
 
 	/* base64 encode it */
@@ -2222,7 +2280,7 @@ void Net::Server::Server::DecompressData(BYTE*& data, size_t& size, size_t origi
 	size = m_iUncompressedLen;
 
 #ifdef DEBUG
-	NET_LOG_DEBUG(CSTRING("'%s' => decompressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
+	NET_LOG_DEBUG(CSTRING("WinNet :: Server('%s') => decompressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
 #endif
 }
 
@@ -2248,7 +2306,7 @@ void Net::Server::Server::DecompressData(BYTE*& data, BYTE*& out, size_t& size, 
 	size = m_iUncompressedLen;
 
 #ifdef DEBUG
-	NET_LOG_DEBUG(CSTRING("'%s' => decompressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
+	NET_LOG_DEBUG(CSTRING("WinNet :: Server('%s') => decompressed data from size %llu to %llu"), SERVERNAME(this), PrevSize, size);
 #endif
 }
 
@@ -2261,35 +2319,35 @@ NET_PACKET_DEFINITION_END
 NET_BEGIN_PACKET(Net::Server::Server, NetProtocolHandshake);
 if (!(PKG[CSTRING("NET_STATUS")] && PKG[CSTRING("NET_STATUS")]->is_int()))
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => missing or bad datatype of 'NET_STATUS' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => missing or bad datatype of 'NET_STATUS' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, 0, true);
 	return;
 }
 
 if (!(PKG[CSTRING("NET_MAJOR_VERSION")] && PKG[CSTRING("NET_MAJOR_VERSION")]->is_int()))
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => missing or bad datatype of 'NET_MAJOR_VERSION' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => missing or bad datatype of 'NET_MAJOR_VERSION' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, 0, true);
 	return;
 }
 
 if (!(PKG[CSTRING("NET_MINOR_VERSION")] && PKG[CSTRING("NET_MINOR_VERSION")]->is_int()))
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => missing or bad datatype of 'NET_MINOR_VERSION' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => missing or bad datatype of 'NET_MINOR_VERSION' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, 0, true);
 	return;
 }
 
 if (!(PKG[CSTRING("NET_REVISION_VERSION")] && PKG[CSTRING("NET_REVISION_VERSION")]->is_int()))
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => missing or bad datatype of 'NET_REVISION_VERSION' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => missing or bad datatype of 'NET_REVISION_VERSION' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, 0, true);
 	return;
 }
 
 if (!(PKG[CSTRING("NET_KEY")] && PKG[CSTRING("NET_KEY")]->is_string()))
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => missing or bad datatype of 'NET_KEY' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => missing or bad datatype of 'NET_KEY' attribute in NetProtocolHandshake. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, 0, true);
 	return;
 }
@@ -2335,7 +2393,7 @@ if ((NET_MAJOR_VERSION == Version::Major())
 
 		peer->estabilished = true;
 
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => Connection to Peer estabilished."), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Connection to Peer estabilished."), SERVERNAME(this), peer->IPAddr().get());
 
 		Net::Timer::WaitSingleObjectStopped(peer->hWaitForNetProtocol);
 		peer->hWaitForNetProtocol = nullptr;
@@ -2355,7 +2413,7 @@ if ((NET_MAJOR_VERSION == Version::Major())
 }
 else
 {
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => Peer sent not matching Net-Version. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Peer sent not matching Net-Version. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, NET_ERROR_CODE::NET_ERR_Versionmismatch);
 }
 NET_END_PACKET;
@@ -2364,26 +2422,26 @@ NET_BEGIN_PACKET(Net::Server::Server, RSAHandshake)
 /* check for wrong protocol behaviour */
 if (!(Isset(NET_OPT_USE_CIPHER) ? GetOption<bool>(NET_OPT_USE_CIPHER) : NET_OPT_DEFAULT_USE_CIPHER))
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => Peer sent Asymmetric Handshake Packet, but cipher mode is disabled."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => Peer sent Asymmetric Handshake Packet, but cipher mode is disabled."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, NET_ERROR_CODE::NET_ERR_Handshake);
 	return;
 }
 else if (peer->estabilished)
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => Peer sent Asymmetric Handshake Packet, but peer's state is set to estabilished."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => Peer sent Asymmetric Handshake Packet, but peer's state is set to estabilished."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, NET_ERROR_CODE::NET_ERR_Handshake);
 	return;
 }
 else if (peer->cryption.getHandshakeStatus())
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => Peer sent more than one Asymmetric Handshake Packet"), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => Peer sent more than one Asymmetric Handshake Packet"), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, NET_ERROR_CODE::NET_ERR_Handshake);
 	return;
 }
 
 if (!(PKG[CSTRING("PublicKey")] && PKG[CSTRING("PublicKey")]->is_string())) // empty
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => missing or bad datatype of 'PublicKey' attribute in Asymmetric Handshake Packet. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => missing or bad datatype of 'PublicKey' attribute in Asymmetric Handshake Packet. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, NET_ERROR_CODE::NET_ERR_Handshake);
 	return;
 }
@@ -2401,7 +2459,7 @@ if (!(PKG[CSTRING("PublicKey")] && PKG[CSTRING("PublicKey")]->is_string())) // e
 	peer->cryption.setHandshakeStatus(true);
 }
 
-NET_LOG_PEER(CSTRING("'%s' :: [%s] => Asymmetric Handshake with Peer was successful."), SERVERNAME(this), peer->IPAddr().get());
+NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Asymmetric Handshake with Peer was successful."), SERVERNAME(this), peer->IPAddr().get());
 
 /* Asymmetric Handshake done. Estabilish Peer connection */
 {
@@ -2411,7 +2469,7 @@ NET_LOG_PEER(CSTRING("'%s' :: [%s] => Asymmetric Handshake with Peer was success
 
 	peer->estabilished = true;
 
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => Connection to Peer estabilished."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Connection to Peer estabilished."), SERVERNAME(this), peer->IPAddr().get());
 
 	Net::Timer::WaitSingleObjectStopped(peer->hWaitForNetProtocol);
 	peer->hWaitForNetProtocol = nullptr;
@@ -2433,7 +2491,7 @@ NET_END_PACKET
 NET_BEGIN_PACKET(Net::Server::Server, NetHeartbeat);
 if (!(PKG[CSTRING("NET_SEQUENCE_NUMBER")] && PKG[CSTRING("NET_SEQUENCE_NUMBER")]->is_int()))
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => missing or bad datatype of 'NET_SEQUENCE_NUMBER' attribute in Heartbeat Packet. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => missing or bad datatype of 'NET_SEQUENCE_NUMBER' attribute in Heartbeat Packet. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, 0, true);
 	return;
 }
@@ -2441,7 +2499,7 @@ if (!(PKG[CSTRING("NET_SEQUENCE_NUMBER")] && PKG[CSTRING("NET_SEQUENCE_NUMBER")]
 /* check for expected sequence number does match */
 if (peer->m_heartbeat_expected_sequence_number != PKG[CSTRING("NET_SEQUENCE_NUMBER")]->as_int())
 {
-	NET_LOG_ERROR(CSTRING("'%s' :: [%s] => Expected heartbeat sequence number does not match. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') '%s' => Expected heartbeat sequence number does not match. Connection to the peer will be dropped immediately."), SERVERNAME(this), peer->IPAddr().get());
 	DisconnectPeer(peer, 0, true);
 	return;
 }

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -216,7 +216,24 @@ NET_PEER Net::WebSocket::Server::CreatePeer(const sockaddr_in client_addr, const
 	peer->client_addr = client_addr;
 	peer->ssl = nullptr;
 
-	// Set socket options
+	/*
+	* Set default socket options for non-blocking mode
+	*/
+	{
+		timeval tv = {};
+		tv.tv_sec = 0;
+		tv.tv_usec = 0;
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_SNDBUF, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVBUF, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_SNDLOWAT, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVLOWAT, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_SNDTIMEO, (char*)&tv, sizeof tv);
+		Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&tv, sizeof tv);
+	}
+
+	/*
+	* Set/override socket options
+	*/
 	for (const auto& entry : socketoption)
 	{
 		const auto res = Ws2_32::setsockopt(peer->pSocket, entry->level, entry->opt, entry->value(), entry->optlen());

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -26,7 +26,7 @@
 #include <Net/Import/Kernel32.hpp>
 #include <Net/Import/Ws2_32.hpp>
 
-FORCEINLINE BYTE SetSocket2NonBlockingMode(SOCKET fd)
+inline BYTE SetSocket2NonBlockingMode(SOCKET fd)
 {
 	if (fd < 0)
 	{

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -239,16 +239,18 @@ NET_PEER Net::WebSocket::Server::CreatePeer(const sockaddr_in client_addr, const
 	peer->ssl = nullptr;
 
 	/*
-	* This library is based on non-blocking sockets, so we need to set the socket to non-blocking mode
+	* This library is based on non-blocking sockets
+	* so we need to set the socket to non-blocking mode
 	*/
 	if (SetSocket2NonBlockingMode(socket) == 0)
 	{
-		NET_LOG_ERROR(CSTRING("[%s] - failed to set socket to non-blocking mode\n\tclosing socket"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => failed to enable non-blocking for socket '%d'\n\tdiscarding socket"), SERVERNAME(this), socket);
 		return nullptr;
 	}
 
 	/*
-	* Set default socket options for non-blocking mode
+	* Set up socket for non-blocking mode
+	* Set everything to 0 so recv and send will return immediately
 	*/
 	{
 		timeval tv = {};
@@ -268,7 +270,10 @@ NET_PEER Net::WebSocket::Server::CreatePeer(const sockaddr_in client_addr, const
 	for (const auto& entry : socketoption)
 	{
 		const auto res = Ws2_32::setsockopt(peer->pSocket, entry->level, entry->opt, entry->value(), entry->optlen());
-		if (res == SOCKET_ERROR) NET_LOG_ERROR(CSTRING("[%s] - Following socket option could not been applied { %i : %i }"), SERVERNAME(this), entry->opt, LAST_ERROR);
+		if (res == SOCKET_ERROR)
+		{
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => failed to apply socket option { %i : %i } for socket '%d'"), SERVERNAME(this), entry->opt, LAST_ERROR, socket);
+		}
 	}
 
 	if (Isset(NET_OPT_SSL) ? GetOption<bool>(NET_OPT_SSL) : NET_OPT_DEFAULT_SSL)
@@ -283,13 +288,13 @@ NET_PEER Net::WebSocket::Server::CreatePeer(const sockaddr_in client_addr, const
 		const auto res = SSL_accept(peer->ssl);
 		if (res == 0)
 		{
-			NET_LOG_ERROR(CSTRING("[%s] - The TLS/SSL handshake was not successful but was shut down controlled and by the specifications of the TLS/SSL protocol"), SERVERNAME(this));
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => The TLS/SSL handshake was not successful but was shut down controlled and by the specifications of the TLS/SSL protocol"), SERVERNAME(this));
 			return nullptr;
 		}
 		if (res < 0)
 		{
 			const auto err = SSL_get_error(peer->ssl, res);
-			NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
+			NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
 			ERR_clear_error();
 			return nullptr;
 		}
@@ -303,7 +308,7 @@ NET_PEER Net::WebSocket::Server::CreatePeer(const sockaddr_in client_addr, const
 		//peer->hCalcLatency = Timer::Create(DoCalcLatency, Isset(NET_OPT_INTERVAL_LATENCY) ? GetOption<int>(NET_OPT_INTERVAL_LATENCY) : NET_OPT_DEFAULT_INTERVAL_LATENCY, _DoCalcLatency, true);
 	}
 
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => New peer connected."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => New peer connected."), SERVERNAME(this), peer->IPAddr().get());
 
 	// callback
 	OnPeerConnect(peer);
@@ -358,7 +363,7 @@ bool Net::WebSocket::Server::ErasePeer(NET_PEER peer, bool clear)
 		OnPeerDisconnect(peer, Ws2_32::WSAGetLastError());
 #endif
 
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => finished"), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => finished"), SERVERNAME(this), peer->IPAddr().get());
 
 		peer->clear();
 
@@ -412,11 +417,11 @@ void Net::WebSocket::Server::DisconnectPeer(NET_PEER peer, const int code)
 
 	if (code == 0)
 	{
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => disconnected"), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => disconnected"), SERVERNAME(this), peer->IPAddr().get());
 	}
 	else
 	{
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => disconnected due to the following reason '%s'"), SERVERNAME(this), peer->IPAddr().get(), Net::Codes::NetGetErrorMessage(code));
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => disconnected due to the following reason '%s'"), SERVERNAME(this), peer->IPAddr().get(), Net::Codes::NetGetErrorMessage(code));
 	}
 
 	// now after we have sent him the reason, close connection
@@ -508,20 +513,20 @@ bool Net::WebSocket::Server::Run()
 		ctx = SSL_CTX_new(Net::ssl::NET_CREATE_SSL_OBJECT(Isset(NET_OPT_SSL_METHOD) ? GetOption<int>(NET_OPT_SSL_METHOD) : NET_OPT_DEFAULT_SSL_METHOD));
 		if (!ctx)
 		{
-			NET_LOG_ERROR(CSTRING("[%s] - ctx is NULL"), SERVERNAME(this));
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => ctx is NULL"), SERVERNAME(this));
 			return false;
 		}
 
 		/* Set the key and cert */
 		if (SSL_CTX_use_certificate_file(ctx, Isset(NET_OPT_SSL_CERT) ? GetOption<char*>(NET_OPT_SSL_CERT) : NET_OPT_DEFAULT_SSL_CERT, SSL_FILETYPE_PEM) <= 0)
 		{
-			NET_LOG_ERROR(CSTRING("[%s] - Failed to load %s"), SERVERNAME(this), Isset(NET_OPT_SSL_CERT) ? GetOption<char*>(NET_OPT_SSL_CERT) : NET_OPT_DEFAULT_SSL_CERT);
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => Failed to load %s"), SERVERNAME(this), Isset(NET_OPT_SSL_CERT) ? GetOption<char*>(NET_OPT_SSL_CERT) : NET_OPT_DEFAULT_SSL_CERT);
 			return false;
 		}
 
 		if (SSL_CTX_use_PrivateKey_file(ctx, Isset(NET_OPT_SSL_KEY) ? GetOption<char*>(NET_OPT_SSL_KEY) : NET_OPT_DEFAULT_SSL_KEY, SSL_FILETYPE_PEM) <= 0)
 		{
-			NET_LOG_ERROR(CSTRING("[%s] - Failed to load %s"), SERVERNAME(this), Isset(NET_OPT_SSL_KEY) ? GetOption<char*>(NET_OPT_SSL_KEY) : NET_OPT_DEFAULT_SSL_KEY);
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => Failed to load %s"), SERVERNAME(this), Isset(NET_OPT_SSL_KEY) ? GetOption<char*>(NET_OPT_SSL_KEY) : NET_OPT_DEFAULT_SSL_KEY);
 			return false;
 		}
 
@@ -529,20 +534,20 @@ bool Net::WebSocket::Server::Run()
 		NET_FILEMANAGER fmanager(Isset(NET_OPT_SSL_CA) ? GetOption<char*>(NET_OPT_SSL_CA) : NET_OPT_DEFAULT_SSL_CA);
 		if (!fmanager.file_exists())
 		{
-			NET_LOG_ERROR(CSTRING("[%s] - File does not exits '%s'"), SERVERNAME(this), Isset(NET_OPT_SSL_CA) ? GetOption<char*>(NET_OPT_SSL_CA) : NET_OPT_DEFAULT_SSL_CA);
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => File does not exits '%s'"), SERVERNAME(this), Isset(NET_OPT_SSL_CA) ? GetOption<char*>(NET_OPT_SSL_CA) : NET_OPT_DEFAULT_SSL_CA);
 			return false;
 		}
 
 		if (SSL_CTX_load_verify_locations(ctx, Isset(NET_OPT_SSL_CA) ? GetOption<char*>(NET_OPT_SSL_CA) : NET_OPT_DEFAULT_SSL_CA, nullptr) <= 0)
 		{
-			NET_LOG_ERROR(CSTRING("[%s] - Failed to load %s"), SERVERNAME(this), Isset(NET_OPT_SSL_CA) ? GetOption<char*>(NET_OPT_SSL_CA) : NET_OPT_DEFAULT_SSL_CA);
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => Failed to load %s"), SERVERNAME(this), Isset(NET_OPT_SSL_CA) ? GetOption<char*>(NET_OPT_SSL_CA) : NET_OPT_DEFAULT_SSL_CA);
 			return false;
 		}
 
 		/* verify private key */
 		if (!SSL_CTX_check_private_key(ctx))
 		{
-			NET_LOG_ERROR(CSTRING("[%s] - Private key does not match with the public certificate"), SERVERNAME(this));
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => Private key does not match with the public certificate"), SERVERNAME(this));
 			ERR_print_errors_fp(stderr);
 			return false;
 		}
@@ -553,7 +558,7 @@ bool Net::WebSocket::Server::Run()
 					NET_LOG(CSTRING("CALLBACK CTX SET INFO!"));
 			});*/
 
-		NET_LOG_DEBUG(CSTRING("[%s] - Server is using method: %s"), SERVERNAME(this), Net::ssl::GET_SSL_METHOD_NAME(Isset(NET_OPT_SSL_METHOD) ? GetOption<int>(NET_OPT_SSL_METHOD) : NET_OPT_DEFAULT_SSL_METHOD).data());
+		NET_LOG_DEBUG(CSTRING("WinNet :: Server('%s') => Server is using method: %s"), SERVERNAME(this), Net::ssl::GET_SSL_METHOD_NAME(Isset(NET_OPT_SSL_METHOD) ? GetOption<int>(NET_OPT_SSL_METHOD) : NET_OPT_DEFAULT_SSL_METHOD).data());
 	}
 
 	// our sockets for the server
@@ -569,13 +574,13 @@ bool Net::WebSocket::Server::Run()
 	res = Ws2_32::WSAStartup(MAKEWORD(2, 2), &wsaData);
 	if (res != NULL)
 	{
-		NET_LOG_ERROR(CSTRING("[%s] - WSAStartup has been failed with error: %d"), SERVERNAME(this), res);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => WSAStartup has been failed with error: %d"), SERVERNAME(this), res);
 		return false;
 	}
 
 	if (LOBYTE(wsaData.wVersion) != 2 || HIBYTE(wsaData.wVersion) != 2)
 	{
-		NET_LOG_ERROR(CSTRING("[%s] - Could not find a usable version of Winsock.dll"), SERVERNAME(this));
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => Could not find a usable version of Winsock.dll"), SERVERNAME(this));
 		Ws2_32::WSACleanup();
 		return false;
 	}
@@ -592,7 +597,7 @@ bool Net::WebSocket::Server::Run()
 	res = Ws2_32::getaddrinfo(NULLPTR, Port.data(), &hints, &result);
 
 	if (res != 0) {
-		NET_LOG_ERROR(CSTRING("[%s] - getaddrinfo failed with error: %d"), SERVERNAME(this), res);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => getaddrinfo failed with error: %d"), SERVERNAME(this), res);
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
 #endif
@@ -603,7 +608,7 @@ bool Net::WebSocket::Server::Run()
 	SetListenSocket(Ws2_32::socket(result->ai_family, result->ai_socktype, result->ai_protocol));
 
 	if (GetListenSocket() == INVALID_SOCKET) {
-		NET_LOG_ERROR(CSTRING("[%s] - socket failed with error: %ld"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => socket failed with error: %ld"), SERVERNAME(this), LAST_ERROR);
 		Ws2_32::freeaddrinfo(result);
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
@@ -612,22 +617,24 @@ bool Net::WebSocket::Server::Run()
 	}
 
 	/*
-	* This library is based on non-blocking sockets, so we need to set the socket to non-blocking mode
+	* This library is based on non-blocking sockets
+	* so we need to set the socket to non-blocking mode
 	*/
 	if (SetSocket2NonBlockingMode(GetListenSocket()) == 0)
 	{
-		NET_LOG_ERROR(CSTRING("[%s] - failed to set socket to non-blocking mode\n\tclosing socket"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => failed to enable non-blocking for socket '%d'\n\tdiscarding socket"), SERVERNAME(this), GetListenSocket());
 		Ws2_32::closesocket(GetListenSocket());
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
 #endif
+		return false;
 	}
 
 	// Setup the TCP listening socket
 	res = Ws2_32::bind(GetListenSocket(), result->ai_addr, static_cast<int>(result->ai_addrlen));
 
 	if (res == SOCKET_ERROR) {
-		NET_LOG_ERROR(CSTRING("[%s] - bind failed with error: %d"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => bind failed with error: %d"), SERVERNAME(this), LAST_ERROR);
 		Ws2_32::freeaddrinfo(result);
 		Ws2_32::closesocket(GetListenSocket());
 #ifndef BUILD_LINUX
@@ -643,7 +650,7 @@ bool Net::WebSocket::Server::Run()
 	res = Ws2_32::listen(GetListenSocket(), SOMAXCONN);
 
 	if (res == SOCKET_ERROR) {
-		NET_LOG_ERROR(CSTRING("[%s] - listen failed with error: %d"), SERVERNAME(this), LAST_ERROR);
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => listen failed with error: %d"), SERVERNAME(this), LAST_ERROR);
 		Ws2_32::closesocket(GetListenSocket());
 #ifndef BUILD_LINUX
 		Ws2_32::WSACleanup();
@@ -665,7 +672,7 @@ bool Net::WebSocket::Server::Run()
 	Thread::Create(WorkThread, this);
 
 	SetRunning(true);
-	NET_LOG_SUCCESS(CSTRING("[%s] - started on Port: %d"), SERVERNAME(this), SERVERPORT(this));
+	NET_LOG_SUCCESS(CSTRING("WinNet :: Server('%s') => started on Port: %d"), SERVERNAME(this), SERVERPORT(this));
 	return true;
 }
 
@@ -673,7 +680,7 @@ bool Net::WebSocket::Server::Close()
 {
 	if (!IsRunning())
 	{
-		NET_LOG_ERROR(CSTRING("[%s] - Can't close server, because server is not running!"), SERVERNAME(this));
+		NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => Can't close server, because server is not running!"), SERVERNAME(this));
 		return false;
 	}
 
@@ -689,7 +696,7 @@ bool Net::WebSocket::Server::Close()
 	Ws2_32::WSACleanup();
 #endif
 
-	NET_LOG_DEBUG(CSTRING("[%s] - Closed!"), SERVERNAME(this));
+	NET_LOG_DEBUG(CSTRING("WinNet :: Server('%s') => Closed!"), SERVERNAME(this));
 	return true;
 }
 
@@ -710,7 +717,7 @@ short Net::WebSocket::Server::Handshake(NET_PEER peer)
 			if (err != SSL_ERROR_SSL && err != SSL_ERROR_WANT_READ)
 			{
 				ErasePeer(peer);
-				NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
+				NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
 				return WebServerHandshake::HandshakeRet_t::error;
 			}
 
@@ -752,9 +759,9 @@ short Net::WebSocket::Server::Handshake(NET_PEER peer)
 				ErasePeer(peer);
 
 #ifdef BUILD_LINUX
-				if (errno != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+				if (errno != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 #else
-				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 #endif
 
 				return WebServerHandshake::HandshakeRet_t::error;
@@ -768,7 +775,7 @@ short Net::WebSocket::Server::Handshake(NET_PEER peer)
 		{
 			peer->network.reset();
 			ErasePeer(peer);
-			NET_LOG_PEER(CSTRING("'%s' :: [%s] => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
+			NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
 			return WebServerHandshake::HandshakeRet_t::error;
 		}
 
@@ -901,9 +908,9 @@ short Net::WebSocket::Server::Handshake(NET_PEER peer)
 						ErasePeer(peer);
 
 #ifdef BUILD_LINUX
-						if (errno != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+						if (errno != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 #else
-						if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+						if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 #endif
 						return WebServerHandshake::HandshakeRet_t::error;
 					}
@@ -927,7 +934,7 @@ short Net::WebSocket::Server::Handshake(NET_PEER peer)
 			if (!(strcmp(reinterpret_cast<char*>(enc_Sec_Key), CSTRING("")) != 0 && strcmp(entries[stringHost].data(), host) == 0 && strcmp(entries[stringOrigin].data(), origin.get()) == 0))
 			{
 				origin.free();
-				NET_LOG_ERROR(CSTRING("[%s] - Handshake failed:\nReceived from Peer ('%s'):\nHost: %s\nOrigin: %s"), SERVERNAME(this), peer->IPAddr().get(), entries[stringHost].data(), entries[stringOrigin].data());
+				NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => Handshake failed:\nReceived from Peer ('%s'):\nHost: %s\nOrigin: %s"), SERVERNAME(this), peer->IPAddr().get(), entries[stringHost].data(), entries[stringOrigin].data());
 				return WebServerHandshake::HandshakeRet_t::missmatch;
 			}
 		}
@@ -936,7 +943,7 @@ short Net::WebSocket::Server::Handshake(NET_PEER peer)
 		return WebServerHandshake::HandshakeRet_t::success;
 	}
 
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => There was an problem encountered with the websocket handshake."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => There was an problem encountered with the websocket handshake."), SERVERNAME(this), peer->IPAddr().get());
 
 	// clear data
 	peer->network.clear();
@@ -971,7 +978,7 @@ Net::PeerPool::WorkStatus_t PeerWorker(void* pdata)
 			const auto res = server->Handshake(peer);
 			if (res == WebServerHandshake::peer_not_valid)
 			{
-				NET_LOG_PEER(CSTRING("'%s' :: [%s] => There was an error encountered with the peer. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
+				NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => There was an error encountered with the peer. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
 
 				// erase him
 				server->ErasePeer(peer, true);
@@ -985,7 +992,7 @@ Net::PeerPool::WorkStatus_t PeerWorker(void* pdata)
 			}
 			if (res == WebServerHandshake::missmatch)
 			{
-				NET_LOG_PEER(CSTRING("'%s' :: [%s] => Missmatch in the WebSocket handshake. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
+				NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Missmatch in the WebSocket handshake. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
 
 				// erase him
 				server->ErasePeer(peer, true);
@@ -994,7 +1001,7 @@ Net::PeerPool::WorkStatus_t PeerWorker(void* pdata)
 			}
 			if (res == WebServerHandshake::error)
 			{
-				NET_LOG_PEER(CSTRING("'%s' :: [%s] => There was an error on performing the WebSocket handshake. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
+				NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => There was an error on performing the WebSocket handshake. Connection to the peer will be dropped immediately."), SERVERNAME(server), peer->IPAddr().get());
 
 				// erase him
 				server->ErasePeer(peer, true);
@@ -1007,7 +1014,7 @@ Net::PeerPool::WorkStatus_t PeerWorker(void* pdata)
 				peer->estabilished = true;
 				server->OnPeerEstabilished(peer);
 
-				NET_LOG_PEER(CSTRING("'%s' :: [%s] => WebSocket handshake with peer was successful."), SERVERNAME(server), peer->IPAddr().get());
+				NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => WebSocket handshake with peer was successful."), SERVERNAME(server), peer->IPAddr().get());
 			}
 
 			return Net::PeerPool::WorkStatus_t::CONTINUE;
@@ -1046,7 +1053,7 @@ void Net::WebSocket::Server::Acceptor()
 		if (Ws2_32::WSAGetLastError() != WSAEWOULDBLOCK)
 #endif
 		{
-			NET_LOG_ERROR(CSTRING("'%s' => [accept] failed with error %d"), SERVERNAME(this), LAST_ERROR);
+			NET_LOG_ERROR(CSTRING("WinNet :: Server('%s') => [accept] failed with error %d"), SERVERNAME(this), LAST_ERROR);
 		}
 
 		return;
@@ -1216,7 +1223,7 @@ void Net::WebSocket::Server::EncodeFrame(BYTE* in_frame, const size_t frame_leng
 					if (err != SSL_ERROR_SSL && err != SSL_ERROR_WANT_READ)
 					{
 						ErasePeer(peer);
-						NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
+						NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
 					}
 
 					return;
@@ -1241,7 +1248,7 @@ void Net::WebSocket::Server::EncodeFrame(BYTE* in_frame, const size_t frame_leng
 					{
 						buf.free();
 						ErasePeer(peer);
-						if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+						if (ERRNO_ERROR_TRIGGERED) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 						return;
 					}
 #else
@@ -1253,7 +1260,7 @@ void Net::WebSocket::Server::EncodeFrame(BYTE* in_frame, const size_t frame_leng
 					{
 						buf.free();
 						ErasePeer(peer);
-						if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+						if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 						return;
 					}
 #endif
@@ -1287,7 +1294,7 @@ bool Net::WebSocket::Server::DoReceive(NET_PEER peer)
 			if (err != SSL_ERROR_SSL && err != SSL_ERROR_WANT_READ)
 			{
 				ErasePeer(peer);
-				NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
+				NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(err, true).c_str());
 			}
 
 			return true;
@@ -1328,9 +1335,9 @@ bool Net::WebSocket::Server::DoReceive(NET_PEER peer)
 				ErasePeer(peer);
 
 #ifdef BUILD_LINUX
-				if (errno != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
+				if (errno != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(errno).c_str());
 #else
-				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("'%s' :: [%s] => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
+				if (Ws2_32::WSAGetLastError() != 0) NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => %s"), SERVERNAME(this), peer->IPAddr().get(), Net::sock_err::getString(Ws2_32::WSAGetLastError()).c_str());
 #endif
 
 				return true;
@@ -1344,7 +1351,7 @@ bool Net::WebSocket::Server::DoReceive(NET_PEER peer)
 		{
 			peer->network.reset();
 			ErasePeer(peer);
-			NET_LOG_PEER(CSTRING("'%s' :: [%s] => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
+			NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
 			return true;
 		}
 
@@ -1391,7 +1398,7 @@ void Net::WebSocket::Server::DecodeFrame(NET_PEER peer)
 	if (OPC == NET_OPCODE_CLOSE)
 	{
 		ErasePeer(peer);
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
 		return;
 	}
 	if (OPC == NET_OPCODE_PING)
@@ -1468,7 +1475,7 @@ void Net::WebSocket::Server::DecodeFrame(NET_PEER peer)
 	else
 	{
 		ErasePeer(peer);
-		NET_LOG_PEER(CSTRING("'%s' :: [%s] => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
+		NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Connection to peer closed gracefully."), SERVERNAME(this), peer->IPAddr().get());
 		return;
 	}
 
@@ -1675,7 +1682,7 @@ void Net::WebSocket::Server::onSSLTimeout(NET_PEER peer)
 	);
 
 	ErasePeer(peer);
-	NET_LOG_PEER(CSTRING("'%s' :: [%s] => Peer timeout exceeded."), SERVERNAME(this), peer->IPAddr().get());
+	NET_LOG_PEER(CSTRING("WinNet :: Server('%s') '%s' => Peer timeout exceeded."), SERVERNAME(this), peer->IPAddr().get());
 }
 
 NET_NATIVE_PACKET_DEFINITION_BEGIN(Net::WebSocket::Server)

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -293,11 +293,7 @@ bool Net::WebSocket::Server::ErasePeer(NET_PEER peer, bool clear)
 #endif
 					{
 						bBlocked = true;
-#ifdef BUILD_LINUX
-						usleep(FREQUENZ(this) * 1000);
-#else
-						Kernel32::Sleep(FREQUENZ(this));
-#endif
+						continue;
 					}
 				}
 
@@ -860,13 +856,11 @@ short Net::WebSocket::Server::Handshake(NET_PEER peer)
 #ifdef BUILD_LINUX
 					if (errno == EWOULDBLOCK)
 					{
-						usleep(FREQUENZ(this) * 1000);
 						continue;
 					}
 #else
 					if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 					{
-						Kernel32::Sleep(FREQUENZ(this));
 						continue;
 					}
 #endif
@@ -1023,11 +1017,7 @@ void Net::WebSocket::Server::Acceptor()
 			if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 #endif
 			{
-#ifdef BUILD_LINUX
-				usleep(FREQUENZ(this) * 1000);
-#else
-				Kernel32::Sleep(FREQUENZ(this));
-#endif
+				continue;
 			}
 			else
 			{
@@ -1220,7 +1210,6 @@ void Net::WebSocket::Server::EncodeFrame(BYTE* in_frame, const size_t frame_leng
 #ifdef BUILD_LINUX
 					if (errno == EWOULDBLOCK)
 					{
-						usleep(FREQUENZ(this) * 1000);
 						continue;
 					}
 					else
@@ -1233,7 +1222,6 @@ void Net::WebSocket::Server::EncodeFrame(BYTE* in_frame, const size_t frame_leng
 #else
 					if (Ws2_32::WSAGetLastError() == WSAEWOULDBLOCK)
 					{
-						Kernel32::Sleep(FREQUENZ(this));
 						continue;
 					}
 					else

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -40,7 +40,7 @@ inline BYTE SetSocket2NonBlockingMode(SOCKET fd)
 		return 0;
 	}
 
-	flags = blocking ? (flags & ~O_NONBLOCK) : (flags | O_NONBLOCK);
+	flags = (flags | O_NONBLOCK);
 	return (fcntl(fd, F_SETFL, flags) == 0) ? 1 : 0;
 #else
 	unsigned long mode = 1;

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -580,9 +580,16 @@ bool Net::WebSocket::Server::Run()
 		return false;
 	}
 
-	// Set the mode of the socket to be nonblocking
+#ifdef BUILD_LINUX
+	res = fcntl(GetListenSocket(), F_GETFL, 0);
+	if (res != SOCKET_ERROR)
+	{
+		res = fcntl(GetListenSocket(), F_SETFL, flags | O_NONBLOCK);
+	}
+#else
 	u_long iMode = 1;
 	res = Ws2_32::ioctlsocket(GetListenSocket(), FIONBIO, &iMode);
+#endif
 
 	if (res == SOCKET_ERROR)
 	{

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -216,12 +216,6 @@ NET_PEER Net::WebSocket::Server::CreatePeer(const sockaddr_in client_addr, const
 	peer->client_addr = client_addr;
 	peer->ssl = nullptr;
 
-	/* Set Read Timeout */
-	timeval tv = {};
-	tv.tv_sec = Isset(NET_OPT_TIMEOUT_TCP_READ) ? GetOption<long>(NET_OPT_TIMEOUT_TCP_READ) : NET_OPT_DEFAULT_TIMEOUT_TCP_READ;
-	tv.tv_usec = 0;
-	Ws2_32::setsockopt(peer->pSocket, SOL_SOCKET, SO_RCVTIMEO, (char*)&tv, sizeof tv);
-
 	// Set socket options
 	for (const auto& entry : socketoption)
 	{

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -1037,11 +1037,11 @@ void Net::WebSocket::Server::DoSend(NET_PEER peer, const uint32_t id, NET_PACKET
 	);
 
 	if (peer->bErase)
+	{
 		return;
+	}
 
-	SOCKET_NOT_VALID(peer->pSocket) return;
-
-	//std::lock_guard<std::mutex> guard(peer->network._mutex_send);
+	std::lock_guard<std::mutex> guard(peer->network._mutex_send);
 
 	Net::Json::Document doc;
 	doc[CSTRING("ID")] = static_cast<int>(id);
@@ -1068,11 +1068,11 @@ void Net::WebSocket::Server::DoSend(NET_PEER peer, const uint32_t id, BYTE* data
 	);
 
 	if (peer->bErase)
+	{
 		return;
+	}
 
-	SOCKET_NOT_VALID(peer->pSocket) return;
-
-	//std::lock_guard<std::mutex> guard(peer->network._mutex_send);
+	std::lock_guard<std::mutex> guard(peer->network._mutex_send);
 
 	// write packet id as big endian
 	auto newBuffer = ALLOC<BYTE>(size + 5);

--- a/Win-Net/Net/NetWebSocket/WebSocket.cpp
+++ b/Win-Net/Net/NetWebSocket/WebSocket.cpp
@@ -239,6 +239,15 @@ NET_PEER Net::WebSocket::Server::CreatePeer(const sockaddr_in client_addr, const
 	peer->ssl = nullptr;
 
 	/*
+	* This library is based on non-blocking sockets, so we need to set the socket to non-blocking mode
+	*/
+	if (SetSocket2NonBlockingMode(socket) == 0)
+	{
+		NET_LOG_ERROR(CSTRING("[%s] - failed to set socket to non-blocking mode\n\tclosing socket"), SERVERNAME(this), LAST_ERROR);
+		return nullptr;
+	}
+
+	/*
 	* Set default socket options for non-blocking mode
 	*/
 	{

--- a/Win-Net/Net/NetWebSocket/WebSocket.h
+++ b/Win-Net/Net/NetWebSocket/WebSocket.h
@@ -339,9 +339,6 @@ namespace Net
 			size_t count_peers(Net::PeerPool::peer_threadpool_t* pool);
 			size_t count_pools();
 
-			short Handshake(NET_PEER);
-			void Acceptor();
-
 			SSL_CTX* ctx;
 			void onSSLTimeout(NET_PEER);
 
@@ -352,6 +349,8 @@ namespace Net
 			void DoSend(NET_PEER, uint32_t, NET_PACKET&, unsigned char = NET_OPCODE_TEXT);
 			void DoSend(NET_PEER, uint32_t, BYTE*, size_t, unsigned char = NET_OPCODE_BINARY);
 
+			short Handshake(NET_PEER);
+			void Acceptor();
 			bool DoReceive(NET_PEER);
 
 			NET_DEFINE_CALLBACK(void, OnPeerEstabilished, NET_PEER) {}


### PR DESCRIPTION
non-blocking socket is a must in this library
 if the option can not be set, then we discard the connection

- fixed non-blocking mode to be set for incoming sockets
- removed console log thread
- removed console log write to file
 this can be self-handled with the callback methods OnLogA and OnLogW